### PR TITLE
fix(style): Proper numeric font weight handling

### DIFF
--- a/editors/style/utilities/style.test.ts
+++ b/editors/style/utilities/style.test.ts
@@ -15,6 +15,7 @@ import {
 	isFunctionVariable,
 	isKeywordValid,
 	isFunctionValid,
+	getStyleOptionByValue,
 } from './style';
 
 describe('extractNumber', () => {
@@ -641,5 +642,77 @@ describe('isFunctionValid', () => {
 			option = { name: '', value: '', syntax };
 			expect(isFunctionValid(value, option)).toBe(false);
 		});
+	});
+});
+
+describe('getStyleOptionByValue', () => {
+	// Basic numeric matches
+	it('should find exact numeric matches', () => {
+		const options: STYLE_VALUE[] = [
+			{ value: '100', name: 'Thin', syntax: 'length' },
+			{ value: '200', name: 'Bold', syntax: 'length' },
+		];
+		expect(getStyleOptionByValue('100', options)).toEqual({ value: '100', name: 'Thin', syntax: 'length' });
+		expect(getStyleOptionByValue('200', options)).toEqual({ value: '200', name: 'Bold', syntax: 'length' });
+	});
+
+	// Basic non-numeric matches (length comparison)
+	it('should match values with same length when non-numeric', () => {
+		const options: STYLE_VALUE[] = [
+			{ value: '10px', name: 'Small', syntax: 'length' },
+			{ value: '10%', name: 'Medium', syntax: 'length' },
+			{ value: 'auto', name: 'Auto', syntax: 'keyword' },
+		];
+
+		expect(getStyleOptionByValue('10px', options)).toEqual({ value: '10px', name: 'Small', syntax: 'length' });
+		expect(getStyleOptionByValue('10%', options)).toEqual({ value: '10%', name: 'Medium', syntax: 'length' });
+		expect(getStyleOptionByValue('auto', options)).toEqual({ value: 'auto', name: 'Auto', syntax: 'keyword' });
+	});
+
+	// No match cases
+	it('should return undefined when no match found', () => {
+		const options: STYLE_VALUE[] = [
+			{ value: '20rem', name: 'Medium', syntax: 'length' },
+			{ value: 'normal', name: 'Normal', syntax: 'keyword' },
+			{ value: 'bold', name: 'Bold', syntax: 'keyword' },
+		];
+		expect(getStyleOptionByValue('italic', options)).toBeUndefined();
+		expect(getStyleOptionByValue('100', options)).toBeUndefined();
+		expect(getStyleOptionByValue('20%', options)).toBeUndefined();
+	});
+
+	// Single option cases
+	it('should return the single option regardless of value', () => {
+		const singleOption: STYLE_VALUE[] = [{ value: '400', name: 'Regular', syntax: 'number' }];
+		expect(getStyleOptionByValue('100', singleOption)).toEqual({ value: '400', name: 'Regular', syntax: 'number' });
+		expect(getStyleOptionByValue('abc', singleOption)).toEqual({ value: '400', name: 'Regular', syntax: 'number' });
+	});
+
+	// Edge cases
+	it('should handle empty or invalid options', () => {
+		expect(getStyleOptionByValue('100', [])).toBeUndefined();
+		expect(getStyleOptionByValue('100', null as any)).toBeUndefined();
+	});
+
+	it('should handle empty or invalid values', () => {
+		const options: STYLE_VALUE[] = [
+			{ value: '10px', name: 'Small', syntax: 'length' },
+			{ value: '20px', name: 'Large', syntax: 'length' },
+		];
+		expect(getStyleOptionByValue('', options)).toBeUndefined();
+		expect(getStyleOptionByValue(null as any, options)).toBeUndefined();
+	});
+
+	// Mixed cases
+	it('should handle mixed numeric and non-numeric options correctly', () => {
+		const mixedOptions: STYLE_VALUE[] = [
+			{ value: '100px', name: 'px', syntax: 'length' },
+			{ value: '100', name: '100', syntax: 'length' },
+			{ value: 'bold', name: 'Bold', syntax: 'keyword' },
+		];
+
+		expect(getStyleOptionByValue('100', mixedOptions)).toEqual({ value: '100', name: '100', syntax: 'length' });
+		expect(getStyleOptionByValue('100px', mixedOptions)).toEqual({ value: '100px', name: 'px', syntax: 'length' });
+		expect(getStyleOptionByValue('bold', mixedOptions)).toEqual({ value: 'bold', name: 'Bold', syntax: 'keyword' });
 	});
 });

--- a/editors/style/utilities/style.tsx
+++ b/editors/style/utilities/style.tsx
@@ -1021,11 +1021,14 @@ export const isSingleValueValid = (property: STYLES_CONSTANTS_KEY, value: string
     const options = STYLES_CONSTANTS[property]?.options;
     const option = getStyleOptionByValue(value, options);
 
+
     // If no option found 
     if (!option) {
         devLog.error(`Couldn't find matching option for property:'${property}' and value:'${value}'`);
         return false;
     }
+
+
 
     // Validate option
     return isOptionValid(value, option);
@@ -1095,15 +1098,50 @@ export const splitSyntax = (input: string): string[] | undefined => {
 }
 
 
-
+/**
+ * Finds a style option from an array that matches the given value.
+ * The matching logic differs based on whether the value is numeric or not.
+ * 
+ * @param {string} value - The style value to match against options. 
+ *                         Examples: "100", "12px", "bold"
+ * @param {STYLE_VALUE[]} options - Array of style options to search through.
+ *                                  Example: [{value: "100", name: "Thin"}, 
+ *                                           {value: "10px", name: "px"}]
+ * 
+ * @returns {STYLE_VALUE | undefined} The matching style option or undefined if not found.
+ * 
+ * @example
+ * // Numeric value match
+ * options = [{value: "100", name: "Thin"},{value: "200", name: "200"}]
+ * getStyleOptionByValue("100", options); * // returns {value: "100", name: "Thin"}
+ * 
+ * // Non-numeric value match
+ * options = [{value: "10px", name: "Medium"}, *{value: "10rem", name: "Small"}]
+ * getStyleOptionByValue("10px", options); * // returns {value: "10px", name: "Small"}
+ * 
+ * // No match found
+ * options = [{value: "normal", name: "Normal"}]
+ * getStyleOptionByValue("bold", options); * // returns undefined
+*/
 export const getStyleOptionByValue = (value: string, options: STYLE_VALUE[]): STYLE_VALUE | undefined => {
+
+    // Check if options is a valid non-empty array
     if (!Array.isArray(options) || options.length <= 0) {
         devLog.error(`Options should be non-empty array<STYLE_VALUE[]>.`);
         return undefined;
     }
 
+    // If there's only one option, return it immediately
     if (options.length === 1) return options[0];
 
+    // Handle numeric values (like font-weight: 100, 200, etc.)
+    if (isNumeric(value)) {
+        return options.find((option) => {
+            return option.value === value;
+        });;
+    }
+
+    // Handle other values by comparing extracted length values
     return options.find((option) => {
         return extractLength(option.value) === extractLength(value);
     });;

--- a/utilities/string.tsx
+++ b/utilities/string.tsx
@@ -38,6 +38,7 @@ export function isLetters(input: unknown): boolean {
         input.length > 0 &&
         /^[a-zA-Z]+(-[a-zA-Z]+)*$/.test(input);
 }
+
 /**
  * Checks whether the given value is a valid number.
  *


### PR DESCRIPTION
## What's Fixed
- Font weight now properly accepts all standard values (100-900)
- Fixed numeric value handling in `getStyleOptionByValue`

## Changes Made
- Updated `getStyleOptionByValue()` logic
- Added comprehensive JSDoc comments
- Added test coverage

## Testing Performed
- [x] Verified all weights work in UI
- [x] Confirmed tests pass
- [x] Checked persistence after refresh